### PR TITLE
Workaround pydub issues on Win 11

### DIFF
--- a/server/src/transcript2snippets.py
+++ b/server/src/transcript2snippets.py
@@ -8,9 +8,9 @@ from pydub import exceptions as pydub_exceptions
 from . import file_io
 
 ffmpeg = os.environ['FFMPEG']
-AudioSegment.converter = '{ffmpeg}\\ffmpeg.exe'
+print("Using FFmpeg path:", ffmpeg)
+AudioSegment.converter = '{ffmpeg}'
 AudioSegment.ffmpeg = '{ffmpeg}\\ffmpeg.exe'
-AudioSegment.ffprobe = '{ffmpeg}\\ffprobe.exe'
 
 MAX_SNIPPET_LEN_SECS = 5
 WORDS_PER_SECOND = 3
@@ -59,11 +59,10 @@ def _extract_snippets(
     except pydub_exceptions.CouldntDecodeError:
         print("Error: Could not decode audio file. Is it a valid file format?")
         return {}
-    except FileNotFoundError:
+    except FileNotFoundError as e:
+        print(f"FileNotFoundError: {e}")
         # This might indicate ffmpeg/ffprobe is not installed or not in PATH
-        print(
-            "Error: Could not process audio. Is FFmpeg/FFprobe installed and in PATH?"
-        )
+        print("Error: Could not process audio. Is FFmpeg/FFprobe installed and in PATH?")
         return {}
     except Exception as e:
         print(f"Error loading audio with pydub: {e}")

--- a/server/transcribe_file.py
+++ b/server/transcribe_file.py
@@ -44,16 +44,27 @@ def transcribe(file_path, audio_data):
             print("Failed to transcribe audio.")
             return None
         
-        snippets = transcript_to_snippets(audio_data, transcript.get("utterances"))
-        if not snippets:
-            print("Failed to extract snippets from transcript.")
-            return None
-        
+        utterances = transcript.get("utterances")
         speaker_map = {}
-        
-        if len(snippets) > 1:
-            print("Multiple speakers detected, initiating speaker identification...")
-            speaker_map = _identify_speakers(snippets)
+
+        try:
+            snippets = transcript_to_snippets(audio_data, utterances)
+            if not snippets:
+                raise ValueError("Failed to extract snippets from transcript.")
+            
+            if len(snippets) > 1:
+                print("Multiple speakers detected, initiating speaker identification...")
+                speaker_map = _identify_speakers(snippets)
+            
+        except Exception as e:
+            print(f"Error extracting snippets: {e}")
+            generic_labels = { utterance["speaker"] for utterance in utterances }
+
+            if len(generic_labels) > 1:
+                print("Multiple speakers detected, assigning generic labels...")
+                speaker_map = { speaker: f"Speaker {speaker}" for speaker in generic_labels }
+
+        print(f"Speaker mapping: {speaker_map}")
 
         # Generate the final session transcript
         session_transcript = transcript_to_session(transcript, speaker_map)


### PR DESCRIPTION
No matter what I do, I can't seem to force pydub to use the installed ffmpeg. So rather than outputting nothing in the event of an exception, we instead fall back to generic speaker labels (which can easily be find-replaced in the transcript later).